### PR TITLE
Chore: Vulnerability remediation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,13 +79,13 @@ nexusPublishing {
 val signingKey: String? by project
 val signingPassword: String? by project
 val requireSigning = project.hasProperty("forceSigning") || project.hasProperty("releasing")
-if(signingKey != null && signingPassword != null) {
+if (signingKey != null && signingPassword != null) {
     signing {
         isRequired = requireSigning
         useInMemoryPgpKeys(signingKey, signingPassword)
         sign(publishing.publications["nebula"])
     }
-} else if(requireSigning) {
+} else if (requireSigning) {
     throw RuntimeException("Artifact signing is required, but signingKey and/or signingPassword are null")
 }
 
@@ -105,6 +105,12 @@ var rewriteVersion = if(project.hasProperty("releasing")) {
 }
 
 dependencies {
+    constraints {
+        implementation("com.fasterxml.woodstox:woodstox-core:6.5.0") {
+            because("Versions <= 6.3.1 contain vulnerabilities")
+        }
+    }
+
     compileOnly("org.projectlombok:lombok:latest.release")
     annotationProcessor("org.projectlombok:lombok:latest.release")
 

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2023-02-27Z">
+    <suppress until="2023-03-27Z">
         <notes>
             <![CDATA[
             file name: snakeyaml-1.33.jar
@@ -11,15 +11,5 @@
         <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
         <cve>CVE-2021-4235</cve>
         <cve>CVE-2022-1471</cve>
-    </suppress>
-    <suppress until="2023-02-27Z">
-        <notes><![CDATA[
-        file name: woodstox-core-6.3.1.jar
-        Severity: HIGH
-        False positive. We do not use woodstox and it will be updated with the next spring cloud
-        dependencies.
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.woodstox/woodstox\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2022-40152</vulnerabilityName>
     </suppress>
 </suppressions>


### PR DESCRIPTION
Changes:

- Updated date for non-applicable/un-actionable suppression.
- Pinned `com.fasterxml.woodstox:woodstox-core` to `6.5.0` to remove vulnerability.