### PR TITLE
Vulnerability remediation: Added suppression for un-actionable dependencies.

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -21,4 +21,19 @@
         <packageUrl regex="true">^pkg:maven/org\.codehaus\.woodstox/stax2\-api@.*$</packageUrl>
         <cve>CVE-2022-40152</cve>
     </suppress>
+    <suppress until="2023-04-09Z">
+        <notes><![CDATA[
+            file name: jackson-core-2.13.4.jar
+            This is not actionable, the latest version is 2.14.2 which still contains the vulnerability.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-core@.*$</packageUrl>
+        <cve>CVE-2022-45688</cve>
+    </suppress>
+    <suppress until="2023-04-09Z">
+        <notes><![CDATA[
+            file name: javax.json-1.1.4.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.glassfish/javax\.json@.*$</packageUrl>
+        <cve>CVE-2022-45688</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
`jackson-core` comes from https://github.com/openrewrite/rewrite-build-gradle-plugin/blob/d1208fe51916896ca6ba85995030e3ffc9ce2d35/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java#L41, the latest version is `2.14.2` and still contains the vulnerability. I suppressed the report for 30 days since it was not actionable.

`javax-json` is the `latest.release`. I suppressed the report for 30 days since it was not 